### PR TITLE
Switch to using moodycamel's ConcurrentQueue

### DIFF
--- a/include/thread_pool/thread_pool.hpp
+++ b/include/thread_pool/thread_pool.hpp
@@ -60,6 +60,17 @@ public:
      * @brief post Try post job to thread pool.
      * @param handler Handler to be called from thread pool worker. It has
      * to be callable as 'handler()'.
+     * @param name Name to be set as thread name. Must have max length 15 For linux.
+     * @return 'true' on success, false otherwise.
+     * @note All exceptions thrown by handler will be suppressed.
+     */
+    template <typename Handler>
+    bool tryPost(Handler&& handler, std::string& name);
+
+    /**
+     * @brief post Try post job to thread pool.
+     * @param handler Handler to be called from thread pool worker. It has
+     * to be callable as 'handler()'.
      * @return 'true' on success, false otherwise.
      * @note All exceptions thrown by handler will be suppressed.
      */
@@ -134,9 +145,17 @@ ThreadPoolImpl<Task, Queue>::operator=(ThreadPoolImpl<Task, Queue>&& rhs) noexce
 
 template <typename Task, template<typename> class Queue>
 template <typename Handler>
+inline bool ThreadPoolImpl<Task, Queue>::tryPost(Handler&& handler, std::string& name)
+{
+    return getWorker().post(std::forward<Handler>(handler), std::move(name));
+}
+
+template <typename Task, template<typename> class Queue>
+template <typename Handler>
 inline bool ThreadPoolImpl<Task, Queue>::tryPost(Handler&& handler)
 {
-    return getWorker().post(std::forward<Handler>(handler));
+    std::string dummy("");
+    return tryPost(std::forward<Handler>(handler), dummy);
 }
 
 template <typename Task, template<typename> class Queue>

--- a/include/thread_pool/thread_pool.hpp
+++ b/include/thread_pool/thread_pool.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+
 #include <thread_pool/fixed_function.hpp>
-#include <thread_pool/mpmc_bounded_queue.hpp>
 #include <thread_pool/thread_pool_options.hpp>
 #include <thread_pool/worker.hpp>
+
+#include <concurrentqueue.h>
 
 #include <atomic>
 #include <memory>
@@ -13,10 +15,13 @@
 namespace tp
 {
 
+template <typename Task>
+using ConcurrentQueue = moodycamel::ConcurrentQueue<Task, moodycamel::ConcurrentQueueDefaultTraits>;
+
 template <typename Task, template<typename> class Queue>
 class ThreadPoolImpl;
 using ThreadPool = ThreadPoolImpl<FixedFunction<void(), 128>,
-                                  MPMCBoundedQueue>;
+                                  ConcurrentQueue>;
 
 /**
  * @brief The ThreadPool class implements thread pool pattern.

--- a/include/thread_pool/worker.hpp
+++ b/include/thread_pool/worker.hpp
@@ -168,7 +168,7 @@ inline void Worker<Task, Queue>::threadFunc(size_t id, Worker* steal_donor)
             try
             {
 #if defined(__unix__) || defined(__rtems__)
-                if (handlerPair.second.size() > 0) {
+                if (!handlerPair.second.empty()) {
                     pthread_setname_np(m_thread.native_handle(), handlerPair.second.c_str());
                 }
 #endif

--- a/tests/thread_pool.t.cpp
+++ b/tests/thread_pool.t.cpp
@@ -32,6 +32,39 @@ TEST(ThreadPool, postJob)
     ASSERT_EQ(42, r.get());
 }
 
+TEST(ThreadPool, tryPostJob)
+{
+    tp::ThreadPool pool;
+
+    std::packaged_task<int()> t([]()
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            return 42;
+        });
+
+    std::future<int> r = t.get_future();
+    std::string name("testThread");
+    pool.tryPost(t, name);
+
+    ASSERT_EQ(42, r.get());
+}
+
+TEST(ThreadPool, tryPostJobNoName)
+{
+    tp::ThreadPool pool;
+
+    std::packaged_task<int()> t([]()
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            return 42;
+        });
+
+    std::future<int> r = t.get_future();
+    pool.tryPost(t);
+
+    ASSERT_EQ(42, r.get());
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/thread_pool.t.cpp
+++ b/tests/thread_pool.t.cpp
@@ -13,10 +13,6 @@ size_t getWorkerIdForCurrentThread()
     return *tp::detail::thread_id();
 }
 
-size_t getWorkerIdForCurrentThread2()
-{
-    return tp::Worker<std::function<void()>, tp::MPMCBoundedQueue>::getWorkerIdForCurrentThread();
-}
 }
 
 TEST(ThreadPool, postJob)


### PR DESCRIPTION
In order to stay consistent with licensing, this commit switches from
using the included queue (which is not on MIT license) to using the
moodycamel ConcurrentQueue that is already used elsewhere in klepsydra
core.