### PR TITLE
Add support for critical tasks.

### DIFF
--- a/include/thread_pool/thread_pool_options.hpp
+++ b/include/thread_pool/thread_pool_options.hpp
@@ -31,6 +31,12 @@ public:
     void setQueueSize(size_t size);
 
     /**
+     * @brief setCritical Set if threadpool deals with critical threads
+     * @param critical True if critical threads, else false.
+     */
+    void setCritical(bool critical);
+
+    /**
      * @brief threadCount Return thread count.
      */
     size_t threadCount() const;
@@ -40,9 +46,11 @@ public:
      */
     size_t queueSize() const;
 
+    bool critical() const;
 private:
     size_t m_thread_count;
     size_t m_queue_size;
+    bool m_is_critical;
 };
 
 /// Implementation
@@ -50,6 +58,7 @@ private:
 inline ThreadPoolOptions::ThreadPoolOptions()
     : m_thread_count(std::max<size_t>(1u, std::thread::hardware_concurrency()))
     , m_queue_size(1024u)
+    , m_is_critical(false)
 {
 }
 
@@ -71,6 +80,16 @@ inline size_t ThreadPoolOptions::threadCount() const
 inline size_t ThreadPoolOptions::queueSize() const
 {
     return m_queue_size;
+}
+
+inline void ThreadPoolOptions::setCritical(bool critical)
+{
+    m_is_critical = critical;
+}
+
+inline bool ThreadPoolOptions::critical() const
+{
+    return m_is_critical;
 }
 
 }

--- a/tests/thread_pool.t.cpp
+++ b/tests/thread_pool.t.cpp
@@ -65,6 +65,27 @@ TEST(ThreadPool, tryPostJobNoName)
     ASSERT_EQ(42, r.get());
 }
 
+TEST(ThreadPool, postJobCritical)
+{
+    tp::ThreadPoolOptions options;
+    options.setThreadCount(1);
+    options.setCritical(true);
+
+    tp::ThreadPool pool(options);
+    std::packaged_task<int()> t([]()
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            return 42;
+        });
+
+    std::future<int> r = t.get_future();
+
+    pool.post(t);
+    ASSERT_THROW(pool.post(t), std::runtime_error);
+
+    ASSERT_EQ(42, r.get());
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
Critical tasks are those which are supposed to run for the entire
duration of the program and cannot wait for threads to free up. If no
threads are free, then program to throw an exception/warn the
user. This adds support for a threadpool that handles such tasks.