### PR TITLE
Reduce scope of setFree in critical threads

### DIFF
--- a/include/thread_pool/safe_queue.h
+++ b/include/thread_pool/safe_queue.h
@@ -56,7 +56,8 @@ public:
      * @param max_num_items
      */
     SafeQueue(unsigned int max_num_items)
-        : m_max_num_items(max_num_items) {}
+        : m_queue()
+        , m_max_num_items(max_num_items) {}
 
     /**
      * @brief SafeQueue

--- a/include/thread_pool/thread_pool.hpp
+++ b/include/thread_pool/thread_pool.hpp
@@ -104,7 +104,7 @@ inline ThreadPoolImpl<Task, Queue>::ThreadPoolImpl(
 
     for(size_t i = 0; i < m_workers.size(); ++i)
     {
-        Worker<Task, Queue>* steal_donor =
+        Worker<Task, Queue>* steal_donor = m_critical ? nullptr :
                                 m_workers[(i + 1) % m_workers.size()].get();
         freeWorkers.setFree(i, true);
         m_workers[i]->start(i, steal_donor);

--- a/include/thread_pool/worker.hpp
+++ b/include/thread_pool/worker.hpp
@@ -167,7 +167,7 @@ inline void Worker<Task, Queue>::threadFunc(size_t id, Worker* steal_donor)
 
     while (m_running_flag.load(std::memory_order_relaxed))
     {
-        if (m_queue.pop(handlerPair) || steal_donor->steal(handlerPair))
+        if (m_queue.pop(handlerPair) || ((steal_donor != nullptr) && (steal_donor->steal(handlerPair))))
         {
             try
             {


### PR DESCRIPTION
In case of critical threads, the workers were set busy when task was
posted. However as other workers can steal the task before the chosen
worker picks up the task to process, this can leave a worker appear
busy even though the task is being processed by another
worker. Reducing the scope of setFree (to function similar to
non-critical threads) ensures that only the worker that is actually
processing the task is set to be busy.

Also fix default initialization of safe queue members.