### PR TITLE
detail::thread_id() implementation with an std::map for KPSR_WITH_FRERTOS

### DIFF
--- a/include/thread_pool/reader_writer_lock.h
+++ b/include/thread_pool/reader_writer_lock.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <condition_variable>
+
+namespace tp
+{
+
+class ReaderWriterLock {
+public:
+    explicit ReaderWriterLock() = default;
+
+    // Locks the mutex for shared ownership, blocks if the mutex is not available
+    void lock_shared()
+    {
+        std::unique_lock<std::mutex> lk(rw_mutex);
+        while (has_writers) {
+            rw_cv.wait(lk);
+        }
+        readers++;
+    }
+
+    // Locks the mutex, blocks if the mutex is not available
+    void lock()
+    {
+        std::unique_lock<std::mutex> lk(rw_mutex);
+        while (has_writers || readers > 0) {
+            rw_cv.wait(lk);
+        }
+        has_writers = true;
+    }
+
+    // Unlocks the mutex
+    void unlock()
+    {
+        std::unique_lock<std::mutex> lk(rw_mutex);
+        has_writers = false;
+        rw_cv.notify_all();
+    }
+
+    // Unlocks the mutex (shared ownership)
+    void unlock_shared()
+    {
+        std::unique_lock<std::mutex> lk(rw_mutex);
+        if (readers == 1)
+            rw_cv.notify_all();
+        readers--;
+    }
+
+private:
+    std::mutex rw_mutex;
+    std::condition_variable rw_cv;
+    uintmax_t readers{0};
+    bool has_writers{false};
+};
+
+}

--- a/include/thread_pool/safe_queue.h
+++ b/include/thread_pool/safe_queue.h
@@ -202,6 +202,10 @@ public:
         return true;
     }
 
+#ifdef __freertos__
+    using uint = uint32_t;
+#endif
+
     /**
      * @brief force_push Move ownership and pushesthe item into the queue, remove previous items if the queue is full.
      * @param item An item.

--- a/tests/non_blocking_thread_pool.t.cpp
+++ b/tests/non_blocking_thread_pool.t.cpp
@@ -10,7 +10,11 @@
 namespace TestLinkage {
 size_t getWorkerIdForCurrentThread()
 {
+#if defined(__freertos__) || defined(KPSR_FREERTOS_EMUL)
+    return tp::detail::thread_id_get();
+#else
     return *tp::detail::thread_id();
+#endif
 }
 
 size_t getWorkerIdForCurrentThread2()


### PR DESCRIPTION
This is only a PR draft. Performance could be enhanced with the use of a reader-writer lock to protect the std::map.

Maybe there is also a better way to have a global std::map object, but I thought this to be the less intrusive implementation.

BTW, it cannot be an `std::vector` instead, though thread `id` are always 0, 1, 2... because we need to find the `Worker id` from the `std::thread_id`, and not as opposite